### PR TITLE
fix issue where we are not returning all the available ingesters in the ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * `cortex_ruler_client_request_duration_seconds`
 * [ENHANCEMENT] Query-frontend/scheduler: added querier forget delay (`-query-frontend.querier-forget-delay` and `-query-scheduler.querier-forget-delay`) to mitigate the blast radius in the event queriers crash because of a repeatedly sent "query of death" when shuffle-sharding is enabled. #3901
 * [BUGFIX] Distributor: reverted changes done to rate limiting in #3825. #3948
+* [BUGFIX] Distributor: fix issue where we are not returning all the available ingesters in the ring. #3977
 
 ## 1.8.0 in progress
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

Fix an issue where extended write does not return all the available instances.

If we checked ingester-1 that's in `az-A`, and it's not active. We'll add `az-A` to distinct zones in the subsequent loops, we'll never check ingesters in  `az-A` again.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
